### PR TITLE
Make tdControllerValue support "name" and "available"

### DIFF
--- a/telldus-core/client/telldus-core.cpp
+++ b/telldus-core/client/telldus-core.cpp
@@ -727,7 +727,7 @@ int WINAPI tdController(int *controllerId, int *controllerType, char *name, int 
 
 /**
  * This function gets a parameter on a controller.
- * Valid parameters are: \c serial, \c name and \c firmware
+ * Valid parameters are: \c serial, \c name, \c available and \c firmware
  *
  * Added in version 2.1.2.
  * @param controllerId The controller to change

--- a/telldus-core/service/ControllerManager.cpp
+++ b/telldus-core/service/ControllerManager.cpp
@@ -279,6 +279,8 @@ std::wstring ControllerManager::getControllerValue(int id, const std::wstring &n
 		return it->second.serial;
 	} else if (name == L"name") {
 		return it->second.name;
+	} else if (name == L"available") {
+		return it->second.controller ? L"1" : L"0";
 	} else if (name == L"firmware") {
 		if (!it->second.controller) {
 			return L"-1";


### PR DESCRIPTION
Feels naturally to support name and available as parameter names in addition to serial and firmware.

The name part was previously reported as ticket 202: http://developer.telldus.com/ticket/202
