### PR TITLE
Add shutdown signaling to unix socket, removing quit delay in tdtool

### DIFF
--- a/telldus-core/common/Socket_unix.cpp
+++ b/telldus-core/common/Socket_unix.cpp
@@ -106,6 +106,8 @@ std::wstring Socket::read(int timeout) {
 		if (response == 0 && timeout > 0) {
 			return L"";
 		} else if (response <= 0) {
+			if(!isConnected())
+				break;
 			FD_SET(d->socket, &d->infds);
 			continue;
 		}
@@ -131,7 +133,10 @@ std::wstring Socket::read(int timeout) {
 void Socket::stopReadWait() {
 	TelldusCore::MutexLocker locker(&d->mutex);
 	d->connected = false;
-	// TODO(stefan): somehow signal the socket here?
+	if(d->socket != -1) {
+		close(d->socket);
+		d->socket = -1;
+	}
 }
 
 void Socket::write(const std::wstring &msg) {


### PR DESCRIPTION
Not sure if something else depends on the sockets returning final data, while shutting down?

Works fine on FreeBSD at least, might want to test on other *NIX/Linux.

Solves the problem with tdtool hanging for a few seconds on exit (since EventSocket in Client::run is blocking; not even used in tdtool?)
