### PR TITLE
Add shutdown signaling to unix socket, removing quit delay in tdtool

### DIFF
--- a/telldus-core/common/Socket_unix.cpp
+++ b/telldus-core/common/Socket_unix.cpp
@@ -130,8 +130,10 @@ std::wstring Socket::read(int timeout) {
 
 void Socket::stopReadWait() {
 	TelldusCore::MutexLocker locker(&d->mutex);
-	d->connected = false;
-	// TODO(stefan): somehow signal the socket here?
+	if(d->connected && d->socket != -1) {
+		d->connected = false;
+		shutdown(d->socket, SHUT_RDWR);
+	}
 }
 
 void Socket::write(const std::wstring &msg) {


### PR DESCRIPTION
Not sure if something else depends on the sockets returning final data, while shutting down?

Works fine on FreeBSD at least, might want to test on other *NIX/Linux.

Solves the problem with tdtool hanging for a few seconds on exit (since EventSocket in Client::run is blocking; not even used in tdtool?)

This fix is very similar to #5, but on FreeBSD just using SHUT_RD did not do the trick.
