### PR TITLE
Python3

### DIFF
--- a/bindings/python/native/setup.py
+++ b/bindings/python/native/setup.py
@@ -109,9 +109,9 @@ if PLATFORM_IS_WINDOWS:
 	except ImportError:
 		class Log:
 			def debug(self, msg, *args):
-				print msg % args
+				print(msg % args)
 			def info(self, msg, *args):
-				print msg % args
+				print(msg % args)
 		log = Log()
 		
 	try:
@@ -137,7 +137,7 @@ if PLATFORM_IS_WINDOWS:
 		sdkdir = os.environ.get("MSSdk")
 		if sdkdir:
 			if DEBUG:
-				print "PSDK: try %%MSSdk%%: '%s'" % sdkdir
+				print("PSDK: try %%MSSdk%%: '%s'" % sdkdir)
 			if os.path.isfile(os.path.join(sdkdir, landmark)):
 				return sdkdir
 		# 2. The "Install Dir" value in the
@@ -152,8 +152,8 @@ if PLATFORM_IS_WINDOWS:
 			pass
 		else:
 			if DEBUG:
-				print r"PSDK: try 'HKLM\Software\Microsoft\MicrosoftSDK"\
-					   "\Directories\Install Dir': '%s'" % sdkdir
+				print(r"PSDK: try 'HKLM\Software\Microsoft\MicrosoftSDK"\
+					   "\Directories\Install Dir': '%s'" % sdkdir)
 			if os.path.isfile(os.path.join(sdkdir, landmark)):
 				return sdkdir
 		# 3. Each installed SDK (not just the platform SDK) seems to have GUID
@@ -173,9 +173,9 @@ if PLATFORM_IS_WINDOWS:
 					pass
 				else:
 					if DEBUG:
-						print r"PSDK: try 'HKLM\Software\Microsoft\MicrosoftSDK"\
+						print(r"PSDK: try 'HKLM\Software\Microsoft\MicrosoftSDK"\
 							   "\InstallSDKs\%s\Install Dir': '%s'"\
-							   % (guid, sdkdir)
+							   % (guid, sdkdir))
 					if os.path.isfile(os.path.join(sdkdir, landmark)):
 						return sdkdir
 				i += 1
@@ -190,8 +190,8 @@ if PLATFORM_IS_WINDOWS:
 			pass
 		else:
 			if DEBUG:
-				print r"PSDK: try 'HKLM\Software\Microsoft\MicrosoftSDKs"\
-					   "\Windows\CurrentInstallFolder': '%s'" % sdkdir
+				print(r"PSDK: try 'HKLM\Software\Microsoft\MicrosoftSDKs"\
+					   "\Windows\CurrentInstallFolder': '%s'" % sdkdir)
 			if os.path.isfile(os.path.join(sdkdir, landmark)):
 				return sdkdir
 	
@@ -203,7 +203,7 @@ if PLATFORM_IS_WINDOWS:
 		]
 		for sdkdir in defaultlocs:
 			if DEBUG:
-				print "PSDK: try default location: '%s'" % sdkdir
+				print("PSDK: try default location: '%s'" % sdkdir)
 			if os.path.isfile(os.path.join(sdkdir, landmark)):
 				return sdkdir
 	
@@ -288,7 +288,7 @@ if PLATFORM_IS_WINDOWS:
 		dev_dir = os.environ.get("TELLDUS_DEVDIR")
 		if dev_dir:
 			if DEBUG:
-				print "Telldus dev dir:" % dev_dir
+				print("Telldus dev dir:" % dev_dir)
 			if os.path.isfile(os.path.join(dev_dir, landmark)):
 				return dev_dir
 
@@ -299,11 +299,11 @@ if PLATFORM_IS_WINDOWS:
 		]
 		for dev_dir in defaultlocs:
 			if DEBUG:
-				print "Telldus dev dir: '%s'" % dev_dir
+				print("Telldus dev dir: '%s'" % dev_dir)
 			if os.path.isfile(os.path.join(dev_dir, landmark)):
 				return dev_dir
 		if DEBUG:
-			print "Telldus dev dir not found, make sure dev code is installed. Or set TELLDUS_DEVDIR."
+			print("Telldus dev dir not found, make sure dev code is installed. Or set TELLDUS_DEVDIR.")
 
 	sdk_dir = find_platform_sdk_dir()
 	sdk_include_dir = os.path.join(sdk_dir, 'Include')

--- a/bindings/python/native/telldus.c
+++ b/bindings/python/native/telldus.c
@@ -2,6 +2,7 @@
 #include "datetime.h"
 #include <telldus-core.h>
 #include <stdio.h>   	
+#include <bytesobject.h>
 
 /* estrdup.c -- duplicate a string, die if error
 	* 
@@ -216,7 +217,7 @@ telldus_tdLastSentValue(PyObject *self, PyObject *args)
 	value = tdLastSentValue(id);
 	retval = estrdup(value);
 	tdReleaseString(value);
-	return PyString_FromString(retval);
+	return PyBytes_FromString(retval);
 }
 
 static PyObject *
@@ -260,7 +261,7 @@ telldus_tdGetErrorString(PyObject *self, PyObject *args)
 	errorString = tdGetErrorString(errorno);
 	retval = estrdup(errorString);
 	tdReleaseString(errorString);
-	return PyString_FromString(retval);
+	return PyBytes_FromString(retval);
 }
 
 static PyObject *
@@ -276,7 +277,7 @@ telldus_tdGetName(PyObject *self, PyObject *args)
 	name = tdGetName(id);
 	retval = estrdup(name);
 	tdReleaseString(name);
-	return PyString_FromString(retval);
+	return PyBytes_FromString(retval);
 }
 
 static PyObject *
@@ -304,7 +305,7 @@ telldus_tdGetProtocol(PyObject *self, PyObject *args)
 	protocol = tdGetProtocol(id);
 	retval = estrdup(protocol);
 	tdReleaseString(protocol);
-	return PyString_FromString(retval);
+	return PyBytes_FromString(retval);
 }
 
 static PyObject *
@@ -333,7 +334,7 @@ telldus_tdGetModel(PyObject *self, PyObject *args)
 	model = tdGetModel(id);
 	retval = estrdup(model);
 	tdReleaseString(model);
-	return PyString_FromString(retval);
+	return PyBytes_FromString(retval);
 }
 
 static PyObject *
@@ -364,7 +365,7 @@ telldus_tdGetDeviceParameter(PyObject *self, PyObject *args)
 	param = tdGetDeviceParameter(id, name, defaultValue);
 	retval = estrdup(param);
 	tdReleaseString(param);
-	return PyString_FromString(retval);
+	return PyBytes_FromString(retval);
 }
 
 static PyObject *
@@ -442,13 +443,13 @@ telldus_tdRegisterDeviceEvent(PyObject *self, PyObject *args)
 	PyObject *func;
 
 	if (!PyArg_ParseTuple(args, "O:tdRegisterDeviceEvent", &func)) {
-		PyErr_SetString(PyExc_StandardError, "Parse error!");
+		PyErr_SetString(PyExc_Exception, "Parse error!");
 		return NULL;
 	}
 		
 	if (!PyCallable_Check(func)) {
 		// Error
-		PyErr_SetString(PyExc_StandardError, "The object should be callable!");
+		PyErr_SetString(PyExc_Exception, "The object should be callable!");
 		return NULL;
 	}
 	
@@ -496,13 +497,13 @@ telldus_tdRegisterDeviceChangeEvent(PyObject *self, PyObject *args)
 	PyObject *func;
 
 	if (!PyArg_ParseTuple(args, "O", &func)) {
-		PyErr_SetString(PyExc_StandardError, "Parse error!");
+		PyErr_SetString(PyExc_Exception, "Parse error!");
 		return NULL;
 	}
 		
 	if (!PyCallable_Check(func)) {
 		// Error
-		PyErr_SetString(PyExc_StandardError, "The object should be callable!");
+		PyErr_SetString(PyExc_Exception, "The object should be callable!");
 		return NULL;
 	}
 	
@@ -550,13 +551,13 @@ telldus_tdRegisterRawDeviceEvent(PyObject *self, PyObject *args)
 	PyObject *func;
 
 	if (!PyArg_ParseTuple(args, "O", &func)) {
-		PyErr_SetString(PyExc_StandardError, "Parse error!");
+		PyErr_SetString(PyExc_Exception, "Parse error!");
 		return NULL;
 	}
 		
 	if (!PyCallable_Check(func)) {
 		// Error
-		PyErr_SetString(PyExc_StandardError, "The object should be callable!");
+		PyErr_SetString(PyExc_Exception, "The object should be callable!");
 		return NULL;
 	}
 	
@@ -604,13 +605,13 @@ telldus_tdRegisterSensorEvent(PyObject *self, PyObject *args)
 	PyObject *func;
 
 	if (!PyArg_ParseTuple(args, "O", &func)) {
-		PyErr_SetString(PyExc_StandardError, "Parse error!");
+		PyErr_SetString(PyExc_Exception, "Parse error!");
 		return NULL;
 	}
 		
 	if (!PyCallable_Check(func)) {
 		// Error
-		PyErr_SetString(PyExc_StandardError, "The object should be callable!");
+		PyErr_SetString(PyExc_Exception, "The object should be callable!");
 		return NULL;
 	}
 	
@@ -745,9 +746,20 @@ static PyMethodDef telldus_methods[] = {
 	{NULL, NULL, 0, NULL}   /* sentinel */
 };
 
-void
-inittelldus(void)
-{
+static struct PyModuleDef telldus_moduledef = {
+        PyModuleDef_HEAD_INIT,
+        "telldus",
+        NULL,
+        -1,
+        telldus_methods,
+        NULL,
+        NULL,
+        NULL,
+        NULL
+};
+
+PyObject *
+PyInit_telldus(void) {
 	PyObject *module;
 	
 	PyObject *TELLSTICK_TURNON_GLUE;
@@ -770,7 +782,7 @@ inittelldus(void)
 		
 	/* Create the module and add the functions */
 	
-	module = Py_InitModule("telldus", telldus_methods);
+	module = PyModule_Create(&telldus_moduledef);
 	
 	TELLSTICK_TURNON_GLUE = PyLong_FromLong((long) TELLSTICK_TURNON);
 	PyObject_SetAttrString(module, "TELLSTICK_TURNON", TELLSTICK_TURNON_GLUE);
@@ -840,4 +852,6 @@ inittelldus(void)
 	PyObject_SetAttrString(module, "TELLSTICK_HUMIDITY", TELLSTICK_HUMIDITY_GLUE);
 	Py_DECREF(TELLSTICK_HUMIDITY_GLUE);
 
+    PyEval_InitThreads();
+    return module;
 }

--- a/bindings/python/native/telldus.c
+++ b/bindings/python/native/telldus.c
@@ -746,6 +746,7 @@ static PyMethodDef telldus_methods[] = {
 	{NULL, NULL, 0, NULL}   /* sentinel */
 };
 
+#if PY_MAJOR_VERSION >= 3
 static struct PyModuleDef telldus_moduledef = {
         PyModuleDef_HEAD_INIT,
         "telldus",
@@ -760,6 +761,11 @@ static struct PyModuleDef telldus_moduledef = {
 
 PyObject *
 PyInit_telldus(void) {
+#else
+void
+inittelldus(void)
+{
+#endif
 	PyObject *module;
 	
 	PyObject *TELLSTICK_TURNON_GLUE;
@@ -782,7 +788,11 @@ PyInit_telldus(void) {
 		
 	/* Create the module and add the functions */
 	
+#if PY_MAJOR_VERSION >= 3
 	module = PyModule_Create(&telldus_moduledef);
+#else
+	module = Py_InitModule("telldus", telldus_methods);
+#endif
 	
 	TELLSTICK_TURNON_GLUE = PyLong_FromLong((long) TELLSTICK_TURNON);
 	PyObject_SetAttrString(module, "TELLSTICK_TURNON", TELLSTICK_TURNON_GLUE);
@@ -852,6 +862,8 @@ PyInit_telldus(void) {
 	PyObject_SetAttrString(module, "TELLSTICK_HUMIDITY", TELLSTICK_HUMIDITY_GLUE);
 	Py_DECREF(TELLSTICK_HUMIDITY_GLUE);
 
+#if PY_MAJOR_VERSION >= 3
     PyEval_InitThreads();
     return module;
+#endif
 }


### PR DESCRIPTION
This is the first steps towards making the python bindings compatible with both python2 and python3.

Running:
`python setup.py build`

Now works using both python-2.7 and python-3.4.

I'm not to sure how the libraries built are later used however. What I have done locally is just to copy the .so file to my project. So any feedback or hints on how to improve this is welcome.
