### PR TITLE
Handle missing configuration without reading undefined values.

### DIFF
--- a/telldus-core/service/SettingsConfuse.cpp
+++ b/telldus-core/service/SettingsConfuse.cpp
@@ -19,6 +19,7 @@ class Settings::PrivateData {
 public:
 	cfg_t *cfg;
 	cfg_t *var_cfg;
+	PrivateData(void) : cfg(NULL), var_cfg(NULL) {};
 };
 
 bool readConfig(cfg_t **cfg);


### PR DESCRIPTION
This solve a minor issue reported by valgrind when there are no
configuration files.  This trigger when these warnings are printed
on startup:

  Unable to open config file, /etc/tellstick.conf
  Unable to open var config file, /var/state/telldus-core.conf

In this case the readConfig() and readVarConfig() functions in
SettingsConfuse.cpp do not set the cfg and var_cfg members of
PrivateData.