### PR TITLE
telldus-core: Use sleep_for instead of usleep

### DIFF
--- a/telldus-core/common/common.h
+++ b/telldus-core/common/common.h
@@ -25,15 +25,13 @@
 #ifdef _WINDOWS
 #include <fstream>  // NOLINT(readability/streams)
 #endif
+#include <chrono>
 #include <string>
+#include <thread>
 #include "common/Strings.h"
 
 inline void msleep( const int msec) {
-#ifdef _WINDOWS
-	Sleep(msec);
-#else
-	usleep(msec*1000);
-#endif
+	std::this_thread::sleep_for(std::chrono::milliseconds(msec));
 }
 
 inline void dlog(const char *fmt, ...) {

--- a/telldus-core/service/TellStick_libftdi.cpp
+++ b/telldus-core/service/TellStick_libftdi.cpp
@@ -8,7 +8,6 @@
 #include <string.h>
 #include <stdlib.h>
 #include <stdio.h>
-#include <unistd.h>
 #include <list>
 #include <string>
 
@@ -231,7 +230,7 @@ int TellStick::send( const std::string &strMessage ) {
 				return TELLSTICK_SUCCESS;
 			}
 		} else if(ret == 0) {  // No data available
-			usleep(100);
+			std::this_thread::sleep_for(std::chrono::microseconds(100));
 		} else {  // Error
 			Log::debug("Broken pipe on read");
 			return TELLSTICK_ERROR_BROKEN_PIPE;


### PR DESCRIPTION
usleep is removed in POSIX 2008 and optionally unavailable in uClibc-ng.

Signed-off-by: Rosen Penev <rosenp@gmail.com>