### PR TITLE
Add missing include needed by Home Assistant build.

### DIFF
--- a/telldus-core/common/Socket_unix.cpp
+++ b/telldus-core/common/Socket_unix.cpp
@@ -8,6 +8,7 @@
 #include <stdio.h>
 #include <unistd.h>
 #include <sys/socket.h>
+#include <sys/select.h>
 #include <sys/un.h>
 #include <fcntl.h>
 #include <math.h>


### PR DESCRIPTION
The Dockerfile rule in
https://github.com/home-assistant/addons/tree/master/tellstick have to
patch Socket_unix.cpp to include a few defines to get it building.